### PR TITLE
Allow site admins to create/edit/delete users when 'Add New Users' option is set

### DIFF
--- a/authorizer.php
+++ b/authorizer.php
@@ -1318,7 +1318,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 				add_options_page(
 					'Authorizer', // Page title
 					'Authorizer', // Menu title
-					'manage_options', // Capability
+					'create_users', // Capability
 					'authorizer', // Menu slug
 					array( $this, 'create_admin_page' ) // function
 				);
@@ -1327,7 +1327,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 				add_menu_page(
 					'Authorizer', // Page title
 					'Authorizer', // Menu title
-					'manage_options', // Capability
+					'create_users', // Capability
 					'authorizer', // Menu slug
 					array( $this, 'create_admin_page' ), // callback
 					'dashicons-groups', // icon
@@ -3297,7 +3297,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 
 		function add_dashboard_widgets() {
 			// Only users who can edit can see the authorizer dashboard widget
-			if ( current_user_can( 'edit_users' ) ) {
+			if ( current_user_can( 'create_users' ) ) {
 				// Add dashboard widget for adding/editing users with access
 				wp_add_dashboard_widget( 'auth_dashboard_widget', 'Authorizer Settings', array( $this, 'add_auth_dashboard_widget' ) );
 			}
@@ -3327,7 +3327,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 		function ajax_update_auth_usermeta() {
 
 			// Fail silently if current user doesn't have permissions.
-			if ( ! current_user_can( 'edit_users' ) ) {
+			if ( ! current_user_can( 'create_users' ) ) {
 				die( '' );
 			}
 
@@ -3361,7 +3361,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 		function ajax_update_auth_user() {
 
 			// Fail silently if current user doesn't have permissions.
-			if ( ! current_user_can( 'edit_users' ) ) {
+			if ( ! current_user_can( 'create_users' ) ) {
 				die( '' );
 			}
 


### PR DESCRIPTION
Changed required user permissions to reflect the 'add_new_users' option. The user capability 'create_users' is tied to this option. This change lets site admins add/edit users in the authorizer settings, but only when the "Add New Users" setting is enabled in network settings.